### PR TITLE
Add python dependencies toml and lz4

### DIFF
--- a/games-strategy/openage/openage-9999.ebuild
+++ b/games-strategy/openage/openage-9999.ebuild
@@ -54,6 +54,8 @@ ncurses? ( sys-libs/ncurses )
 $(python_gen_cond_dep '
     dev-python/numpy[${PYTHON_MULTI_USEDEP}]
     dev-python/pillow[${PYTHON_MULTI_USEDEP}]
+    dev-python/toml[${PYTHON_MULTI_USEDEP}]
+    dev-python/lz4[${PYTHON_MULTI_USEDEP}]
 ')
 "
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Tried installing OpenAge thorugh the ebuild but I was missing the python modules for lz4 and toml. Worked well with them!

Cheers,